### PR TITLE
Better typing for PaylineApi

### DIFF
--- a/src/usePayline.ts
+++ b/src/usePayline.ts
@@ -1,22 +1,31 @@
+// See https://docs.payline.com/display/DT/API+JavaScript for full documentation of Payline API
 type PaylineApi = {
-  endToken: (additionnalData: any, callback: Function, spinner: any, handledByMerchant: boolean) => void;
-  finalizeShortCut: Function;
-  getBuyerShortCut: Function;
-  getCancelAndReturnUrls: Function;
-  getContextInfo: (key: string) => any;
-  getCssIframeWhiteList: Function;
-  getFragmentedPaymentInfo: Function;
-  getLanguage: Function;
-  getOrderInfos: Function;
-  getRecurringDetails: Function;
-  getToken: Function;
-  getTokenStatus: (token: string, callback: (tokenStatus: 'ALIVE' | 'EXPIRED' | 'UNKNOWN') => void) => void;
-  hide: Function;
-  init: Function;
-  isSandBox: Function;
+  endToken: (
+    additionnalData: any,
+    callback: () => void,
+    spinner: any,
+    handledByMerchant: boolean
+  ) => void;
+  finalizeShortCut: () => void;
+  getBuyerShortCut: () => Record<string, unknown>;
+  getCancelAndReturnUrls: () => { returnUrl: string; cancelUrl: string };
+  getContextInfo: (key: string) => Record<string, unknown>;
+  getCssIframeWhiteList: () => string[];
+  getFragmentedPaymentInfo: () => Record<string, unknown>;
+  getLanguage: () => string;
+  getOrderInfos: () => Record<string, unknown>;
+  getRecurringDetails: () => Record<string, unknown>;
+  getToken: () => string;
+  getTokenStatus: (
+    token: string,
+    callback: (tokenStatus: 'ALIVE' | 'EXPIRED' | 'UNKNOWN') => void
+  ) => void;
+  hide: () => void;
+  init: () => void;
+  isSandBox: () => boolean;
   reset: (token?: string, template?: string) => void;
-  show: Function;
-  toggle: Function;
+  show: () => void;
+  toggle: () => void;
   updateWebpaymentData: (token: string, data: any) => void;
 };
 


### PR DESCRIPTION
Better typing for functions, as typescript-eslint prevent using `Function` keyword

> Don't use `Function` as a type. The `Function` type accepts any function-like value.
> It provides no type safety when calling the function, which can be a common source of bugs.
> It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.
> If you are expecting the function to accept certain arguments, you should explicitly define the function [@typescript-eslint/ban-types](https://github.com/typescript-eslint/typescript-eslint/blob/v5.2.0/packages/eslint-plugin/docs/rules/ban-types.md)