### PR TITLE
Change usePayline behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Integrates the [Payline API](https://docs.payline.com/display/DT/API+JavaScript)
 
 ```jsx
 import { useEffect } from 'react';
-import { usePayline } from 'react-payline';
+import { usePaylineApi } from 'react-payline';
 import Payment from './Payment';
 
 function PaymentWrapper(props) {
-  const paylineApi = usePayline();
+  const paylineApi = usePaylineApi();
   useEffect(() => {
     if (props.show) {
       paylineApi.show();

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 export { default as PaylineProvider, PaylineHead } from './src/PaylineProvider';
 export { default as withPayline } from './src/withPayline';
-export { default as usePayline } from './src/usePayline';
-
+export * from './src/usePayline';
 export * from './src/PaylineWidget';

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "devDependencies": {
+    "@types/jquery": "^3.5.16",
     "@types/react": "^16.9.19",
     "react": "^16.12.0",
     "typescript": "^3.7.5"

--- a/src/PaylineWidget.tsx
+++ b/src/PaylineWidget.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import usePayline from './usePayline';
 
-type StateType =
+export type StateType =
   | 'ACTIVE_WAITING'
   | 'BROWSER_NOT_SUPPORTED'
   | 'MANAGE_WEB_WALLET'

--- a/src/PaylineWidget.tsx
+++ b/src/PaylineWidget.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-import usePayline from './usePayline';
+import { usePaylineApi } from './usePayline';
 
 export type StateType =
   | 'ACTIVE_WAITING'
@@ -95,7 +95,7 @@ export const PaylineWidget: React.ComponentType<PaylineWidgetProps> = ({
     };
   }, []);
 
-  const payline = usePayline();
+  const payline = usePaylineApi();
   useEffect(() => {
     if (payline) {
       payline.reset();

--- a/src/usePayline.ts
+++ b/src/usePayline.ts
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 // See https://docs.payline.com/display/DT/API+JavaScript for full documentation of Payline API
 type PaylineApi = {
   endToken: (
@@ -38,8 +40,13 @@ declare global {
 export const usePayline = () => {
   if (typeof window === 'undefined') return undefined;
 
-  if (!window.Payline)
-    throw new Error('window.Payline is unavailable. Check if PaylineProvider is rendered within the component tree.');
+  useEffect(() => {
+    if (!window.Payline && !document.querySelector('script[src$="payline.com/cdn/scripts/widget-min.js"]'))
+      throw new Error(
+        "window.Payline is unavailable. Check if PaylineProvider is rendered within the component tree."
+      );
+  }, []);
+
   return window.Payline;
 };
 

--- a/src/usePayline.ts
+++ b/src/usePayline.ts
@@ -37,7 +37,7 @@ declare global {
   }
 }
 
-export const usePayline = () => {
+const usePayline = () => {
   if (typeof window === 'undefined') return undefined;
 
   useEffect(() => {

--- a/src/usePayline.ts
+++ b/src/usePayline.ts
@@ -35,12 +35,13 @@ declare global {
   }
 }
 
-const usePayline = () => {
+export const usePayline = () => {
   if (typeof window === 'undefined') return undefined;
 
   if (!window.Payline)
     throw new Error('window.Payline is unavailable. Check if PaylineProvider is rendered within the component tree.');
-  return window.Payline.Api;
+  return window.Payline;
 };
 
-export default usePayline;
+export const usePaylineApi = () => usePayline()?.Api;
+export const usePaylineJQuery = () => usePayline()?.jQuery;

--- a/src/usePayline.ts
+++ b/src/usePayline.ts
@@ -31,7 +31,7 @@ type PaylineApi = {
 
 declare global {
   interface Window {
-    Payline?: { Api: PaylineApi };
+    Payline?: { Api: PaylineApi; jQuery: JQuery };
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@types/jquery@^3.5.16":
+  version "3.5.16"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.5.16.tgz#632131baf30951915b0317d48c98e9890bdf051d"
+  integrity sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==
+  dependencies:
+    "@types/sizzle" "*"
+
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
@@ -14,6 +21,11 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/sizzle@*":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
+  integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
 csstype@^2.2.0:
   version "2.6.8"


### PR DESCRIPTION
- usePayline is no more. It is split in two hooks: usePaylineApi and usePaylineJQuery
- payline readiness check has changed. It might be more compatible with some scenarios https://github.com/stadline/react-payline/pull/8